### PR TITLE
注文統計の永続化機能を追加

### DIFF
--- a/src/app/Console/Commands/CleanupStatsLogs.php
+++ b/src/app/Console/Commands/CleanupStatsLogs.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\StatsLog;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class CleanupStatsLogs extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'stats:cleanup {--days=30 : 保持する日数}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '古い統計ログを削除します';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        try {
+            $days = $this->option('days');
+            $this->info("実行開始: {$days}日以前の統計ログを削除します...");
+
+            $beforeCount = StatsLog::count();
+            $deletedCount = StatsLog::where('recorded_at', '<', now()->subDays($days))->delete();
+            $afterCount = StatsLog::count();
+
+            $this->info("----------------------------------------");
+            $this->info("削除完了:");
+            $this->info("- 削除前の総レコード数: {$beforeCount}");
+            $this->info("- 削除されたレコード数: {$deletedCount}");
+            $this->info("- 削除後の総レコード数: {$afterCount}");
+            $this->info("----------------------------------------");
+
+            Log::info('Stats cleanup completed', [
+                'days_threshold' => $days,
+                'records_deleted' => $deletedCount
+            ]);
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            Log::error('Stats cleanup failed:', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            $this->error("エラーが発生しました: " . $e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Log;
 
 class Kernel extends ConsoleKernel
 {
@@ -14,23 +15,85 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         \App\Console\Commands\HealthCommand::class,
+        \App\Console\Commands\CleanupStatsLogs::class,
     ];
 
     /**
      * Define the application's command schedule.
+     *
+     * @param Schedule $schedule
+     * @return void
      */
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command('users:update-online-status')->everyMinute();
+        // ユーザーのオンラインステータス更新（既存）
+        $schedule->command('users:update-online-status')
+            ->everyMinute()
+            ->withoutOverlapping()
+            ->runInBackground();
+
+        // 統計ログのクリーンアップ（新規追加）
+        $schedule->command('stats:cleanup')
+            ->dailyAt('01:00')
+            ->withoutOverlapping()
+            ->runInBackground()
+            ->appendOutputTo(storage_path('logs/stats-cleanup.log'))
+            ->before(function () {
+                Log::info('Starting stats cleanup task');
+            })
+            ->after(function () {
+                Log::info('Stats cleanup task completed');
+            })
+            ->onFailure(function () {
+                Log::error('Stats cleanup task failed');
+            })
+            ->onSuccess(function () {
+                Log::info('Stats cleanup task executed successfully');
+            });
+
+        // 開発環境でのログ出力
+        if (config('app.env') === 'local') {
+            $schedule->command('schedule:list')
+                ->daily()
+                ->appendOutputTo(storage_path('logs/schedule.log'));
+        }
     }
 
     /**
      * Register the commands for the application.
+     *
+     * @return void
      */
     protected function commands(): void
     {
+        // コマンドディレクトリからコマンドを自動で読み込み
         $this->load(__DIR__ . '/Commands');
 
+        // 追加のコンソールルートを読み込み
         require base_path('routes/console.php');
+    }
+
+    /**
+     * Get the timezone that should be used by default for scheduled events.
+     *
+     * @return \DateTimeZone|string|null
+     */
+    protected function scheduleTimezone()
+    {
+        return config('app.timezone', 'Asia/Tokyo');
+    }
+
+    /**
+     * Determine if the given event mutates the application.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function whenEventShouldRunInMaintenanceMode($event): bool
+    {
+        return in_array($event->command, [
+            'stats:cleanup',
+            'users:update-online-status',
+        ]);
     }
 }

--- a/src/app/Events/SalesUpdated.php
+++ b/src/app/Events/SalesUpdated.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SalesUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $totalSales;
+    public $previousSales;
+    public $changeRate;
+
+    public function __construct($totalSales, $previousSales, $changeRate)
+    {
+        $this->totalSales = $totalSales;
+        $this->previousSales = $previousSales;
+        $this->changeRate = $changeRate;
+    }
+
+    public function broadcastOn(): array
+    {
+        return [
+            new Channel('sales-stats'),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        try {
+            return [
+                'totalSales' => $this->totalSales,
+                'previousSales' => $this->previousSales,
+                'changeRate' => $this->changeRate,
+            ];
+        } catch (\Throwable $error) {
+            $exception = new \Exception($error->getMessage(), $error->getCode(), $error);
+            $this->closeError($exception);
+            throw $exception;
+        }
+    }
+}

--- a/src/app/Models/Order.php
+++ b/src/app/Models/Order.php
@@ -8,11 +8,30 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Log;
+use App\Services\StatsService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class Order extends Model
 {
     use HasFactory, HasUuids, SoftDeletes;
 
+    /**
+     * 注文ステータスの定数
+     */
+    const STATUS_PENDING = 'PENDING';
+    const STATUS_PROCESSING = 'PROCESSING';
+    const STATUS_CONFIRMED = 'CONFIRMED';
+    const STATUS_SHIPPED = 'SHIPPED';
+    const STATUS_DELIVERED = 'DELIVERED';
+    const STATUS_CANCELLED = 'CANCELLED';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<string, mixed>
+     */
     protected $fillable = [
         'orderNumber',
         'orderDate',
@@ -24,22 +43,75 @@ class Order extends Model
         'campaignId',
     ];
 
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
     protected $casts = [
         'orderDate' => 'datetime',
         'totalAmount' => 'integer',
         'discountApplied' => 'integer',
     ];
 
-    // 注文ステータスの定数
-    const STATUS_PENDING = 'PENDING';
-    const STATUS_PROCESSING = 'PROCESSING';
-    const STATUS_CONFIRMED = 'CONFIRMED';
-    const STATUS_SHIPPED = 'SHIPPED';
-    const STATUS_DELIVERED = 'DELIVERED';
-    const STATUS_CANCELLED = 'CANCELLED';
+    /**
+     * モデルの「ブート」メソッド
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::updated(function ($order) {
+            if ($order->isDirty('status') && (
+                $order->status === self::STATUS_CANCELLED ||
+                $order->getOriginal('status') === self::STATUS_CANCELLED
+            )) {
+                $lockKey = 'order_stats_update_lock';
+
+                // ロックを使用して重複更新を防ぐ
+                Cache::lock($lockKey, 10)->get(function () use ($order) {
+                    try {
+                        DB::transaction(function () use ($order) {
+                            // 更新前の状態をログに記録
+                            Log::info('Updating stats for order:', [
+                                'order_id' => $order->id,
+                                'previous_status' => $order->getOriginal('status'),
+                                'new_status' => $order->status
+                            ]);
+
+                            $activeOrderCount = self::getActiveOrderCount();
+                            $totalSales = self::getActiveTotalAmount();
+
+                            // 統計更新を実行
+                            $orderStats = app(StatsService::class)->updateStats('order_count', $activeOrderCount);
+                            $salesStats = app(StatsService::class)->updateStats('sales', $totalSales);
+
+                            // 更新後の状態をログに記録
+                            Log::info('Stats updated for order:', [
+                                'order_id' => $order->id,
+                                'active_order_count' => $activeOrderCount,
+                                'total_sales' => $totalSales,
+                                'order_stats' => $orderStats,
+                                'sales_stats' => $salesStats
+                            ]);
+                        });
+                    } catch (\Exception $e) {
+                        Log::error('Failed to update order stats:', [
+                            'error' => $e->getMessage(),
+                            'order_id' => $order->id,
+                            'trace' => $e->getTraceAsString()
+                        ]);
+                        throw $e;
+                    }
+                });
+            }
+        });
+    }
 
     /**
-     * 利用可能な注文ステータス
+     * 利用可能な注文ステータス配列を取得
+     *
+     * @return array<string>
      */
     public static function getAvailableStatuses(): array
     {
@@ -50,6 +122,65 @@ class Order extends Model
             self::STATUS_SHIPPED,
             self::STATUS_DELIVERED,
             self::STATUS_CANCELLED,
+        ];
+    }
+
+    /**
+     * アクティブな注文の総数を取得
+     *
+     * @return int
+     */
+    public static function getActiveOrderCount(): int
+    {
+        // キャッシュキーを定義
+        $cacheKey = 'active_order_count';
+
+        return Cache::remember($cacheKey, 60, function () {
+            // サブクエリを使用して正確な集計を行う
+            return DB::transaction(function () {
+                $orderItems = DB::table('order_items')
+                    ->select('orderId', DB::raw('SUM(quantity) as total_quantity'))
+                    ->whereNull('deleted_at')
+                    ->groupBy('orderId');
+
+                return static::whereNotIn('status', [self::STATUS_CANCELLED])
+                    ->whereNull('deleted_at')
+                    ->joinSub($orderItems, 'items', function ($join) {
+                        $join->on('orders.id', '=', 'items.orderId');
+                    })
+                    ->sum('items.total_quantity');
+            });
+        });
+    }
+
+    /**
+     * アクティブな注文の合計金額を取得
+     *
+     * @return int
+     */
+    public static function getActiveTotalAmount(): int
+    {
+        return static::whereNotIn('status', [self::STATUS_CANCELLED])
+            ->whereNull('orders.deleted_at')  // テーブル名を明示的に指定
+            ->sum('totalAmount');
+    }
+
+    /**
+     * 期間指定での注文統計を取得
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @return array<string, mixed>
+     */
+    public static function getStatsForPeriod(string $startDate, string $endDate): array
+    {
+        $orders = static::whereNotIn('status', [self::STATUS_CANCELLED])
+            ->whereBetween('orderDate', [$startDate, $endDate]);
+
+        return [
+            'count' => $orders->count(),
+            'totalAmount' => $orders->sum('totalAmount'),
+            'avgAmount' => $orders->avg('totalAmount'),
         ];
     }
 
@@ -87,6 +218,8 @@ class Order extends Model
 
     /**
      * 注文合計を再計算 (割引適用前)
+     *
+     * @return int
      */
     public function calculateTotal(): int
     {
@@ -97,19 +230,36 @@ class Order extends Model
 
     /**
      * キャンセル可能かどうかを判定
+     *
+     * @return bool
      */
     public function canBeCancelled(): bool
     {
         return in_array($this->status, [
             self::STATUS_PENDING,
-            self::STATUS_PROCESSING,
-        ]);
+            self::STATUS_PROCESSING
+        ]) && !$this->deleted_at;
+    }
+    /**
+     * 統計ログを取得
+     *
+     * @return StatsLog|null
+     */
+    public static function getOrderStats(): ?StatsLog
+    {
+        return StatsLog::where('metric_type', 'order_count')
+            ->latest('recorded_at')
+            ->first();
     }
 
     /**
-     * 日付範囲内でによる絞り込み
+     * 日付範囲による絞り込み
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string|null $startDate
+     * @param string|null $endDate
+     * @return \Illuminate\Database\Eloquent\Builder
      */
-    // Order.php
     public function scopeDateRange($query, $startDate = null, $endDate = null)
     {
         if ($startDate) {
@@ -123,6 +273,11 @@ class Order extends Model
 
     /**
      * 金額範囲による絞り込み
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param int|null $minAmount
+     * @param int|null $maxAmount
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeAmountRange($query, $minAmount = null, $maxAmount = null)
     {
@@ -137,6 +292,10 @@ class Order extends Model
 
     /**
      * ステータスによる絞り込み
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string|null $status
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWithStatus($query, $status = null)
     {
@@ -146,11 +305,29 @@ class Order extends Model
         return $query;
     }
 
+    /**
+     * 注文番号による検索
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string|null $orderNumber
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeOrderNumberLike($query, $orderNumber)
     {
         if ($orderNumber) {
             return $query->where('orderNumber', 'like', "%{$orderNumber}%");
         }
         return $query;
+    }
+
+    /**
+     * アクティブな注文のみを取得
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeActive($query)
+    {
+        return $query->whereNotIn('status', [self::STATUS_CANCELLED]);
     }
 }

--- a/src/app/Models/StatsLog.php
+++ b/src/app/Models/StatsLog.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+class StatsLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'metric_type',
+        'current_value',
+        'previous_value',
+        'change_rate',
+        'recorded_at'
+    ];
+
+    protected $casts = [
+        'recorded_at' => 'datetime',
+        'change_rate' => 'decimal:2',
+        'current_value' => 'integer',
+        'previous_value' => 'integer',
+    ];
+
+    /**
+     * 特定のメトリクスタイプの最新の統計と取得
+     */
+    public static function getLatestStats(string $metricType): ?self
+    {
+        return static::where('metric_type', $metricType)
+            ->latest('recorded_at')
+            ->first();
+    }
+
+    /**
+     * 特定のメトリクスタイプの統計履歴を取得
+     */
+    public static function getStatsHistory(
+        string $metricType,
+        int $limit = 10
+    ): Collection {
+        return static::where('metric_type', $metricType)
+            ->latest('recorded_at')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * 古い統計データを削除
+     */
+    public static function cleanupOldStats(int $daysToKeep = 30): int
+    {
+        return static::where('recorded_at', '<', now()->subDays($daysToKeep))
+            ->delete();
+    }
+}

--- a/src/app/Services/StatsService.php
+++ b/src/app/Services/StatsService.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\StatsLog;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class StatsService
+{
+    /**
+     * 統計情報を更新
+     *
+     * @param string $metricType 統計の種類
+     * @param int $currentValue 現在の値
+     * @param bool $useSmoothing 将来的なデータ平滑化のためのフラグ（現在は未実装）
+     * @param int|null $forcePreviousValue 強制的に設定する前回値
+     */
+    public function updateStats(string $metricType, int $currentValue): array
+    {
+        $lockKey = "stats_{$metricType}_lock";
+
+        return Cache::lock($lockKey, 10)->block(5, function () use ($metricType, $currentValue) {
+            $latestStats = $this->getLatestStatsLog($metricType);
+
+            // 値が同じ場合は更新をスキップ
+            if ($latestStats && $latestStats->current_value === $currentValue) {
+                Log::info("Stats update skipped - no change", [
+                    'metric_type' => $metricType,
+                    'value' => $currentValue
+                ]);
+                return $this->formatStats($latestStats);
+            }
+
+            $previousValue = $latestStats ? $latestStats->current_value : $currentValue;
+            $changeRate = $this->calculateChangeRate($currentValue, $previousValue);
+
+            $newStats = StatsLog::create([
+                'metric_type' => $metricType,
+                'current_value' => $currentValue,
+                'previous_value' => $previousValue,
+                'change_rate' => $changeRate,
+                'recorded_at' => now()
+            ]);
+
+            Log::info("Stats updated", [
+                'metric_type' => $metricType,
+                'current_value' => $currentValue,
+                'previous_value' => $previousValue,
+                'change_rate' => $changeRate
+            ]);
+
+            return $this->formatStats($newStats);
+        });
+    }
+
+    /**
+     * 最新の統計情報を取得
+     *
+     * @param string $metricType
+     * @return array
+     */
+    public function getLatestStats(string $metricType): array
+    {
+        $stats = $this->getLatestStatsLog($metricType);
+
+        return $stats ? $this->formatStats($stats) : [
+            'currentValue' => 0,
+            'previousValue' => 0,
+            'changeRate' => 0
+        ];
+    }
+
+    /**
+     * 最新の統計ログを取得
+     *
+     * @param string $metricType
+     * @return StatsLog|null
+     */
+    private function getLatestStatsLog(string $metricType): ?StatsLog
+    {
+        return StatsLog::where('metric_type', $metricType)
+            ->latest('recorded_at')
+            ->first();
+    }
+
+    /**
+     * 初期統計を作成
+     *
+     * @param string $metricType
+     * @param int $currentValue
+     * @return StatsLog
+     */
+    private function createInitialStats(string $metricType, int $currentValue): StatsLog
+    {
+        return StatsLog::create([
+            'metric_type' => $metricType,
+            'current_value' => $currentValue,
+            'previous_value' => $currentValue,
+            'change_rate' => 0,
+            'recorded_at' => now()
+        ]);
+    }
+
+    /**
+     * 統計データを配列形式にフォーマット
+     *
+     * @param StatsLog $stats
+     * @return array
+     */
+    private function formatStats(StatsLog $stats): array
+    {
+        return [
+            'currentValue' => $stats->current_value,
+            'previousValue' => $stats->previous_value,
+            'changeRate' => $stats->change_rate
+        ];
+    }
+
+    /**
+     * 変動率を計算
+     *
+     * @param int $current
+     * @param int $previous
+     * @return float
+     */
+    public function calculateChangeRate(int $current, int $previous): float
+    {
+        if ($previous === 0) {
+            return 0;
+        }
+        return round((($current - $previous) / $previous) * 100, 2);
+    }
+}

--- a/src/database/migrations/2024_11_15_113945_create_stats_logs_table.php
+++ b/src/database/migrations/2024_11_15_113945_create_stats_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stats_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('metric_type', 50)->index();
+            $table->integer('current_value');
+            $table->integer('previous_value');
+            $table->decimal('change_rate', 8, 2);
+            $table->timestamp('recorded_at')->index();
+            $table->timestamps();
+
+            // 複合インデックス
+            $table->index(['metric_type', 'recorded_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stats_logs');
+    }
+};

--- a/src/database/seeders/CustomerSeeder.php
+++ b/src/database/seeders/CustomerSeeder.php
@@ -40,7 +40,6 @@ class CustomerSeeder extends Seeder
 
                 $changeRate = $this->calculateChangeRate($totalCount, $previousTotalCount);
 
-                // イベントは発火されませんが、コードは維持
                 event(new CustomerCountUpdated($totalCount, $previousTotalCount, $changeRate));
             }
 

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -21,7 +21,7 @@ class UserSeeder extends Seeder
         $this->createUserIfNotExists('staff', 'staff@example.com', 'STAFF');
 
         // ランダムユーザーの生成
-        $count = 3;
+        $count = 10;
         $chunkSize = 10;
         $totalCount = 0;
 


### PR DESCRIPTION
- stats_logsテーブルを追加し、統計データを永続化
- StatsLogモデルとStatsServiceを実装
- OrderControllerを更新し、統計の永続化に対応
- 統計データのクリーンアップ機能を追加
- キャッシュ制御を最適化

関連コンポーネント:
- マイグレーションファイル
- StatsLogモデル
- StatsService
- OrderController
- クリーンアップコマンド